### PR TITLE
Add step back and max steer recovery

### DIFF
--- a/step_back_and_max_steer_recovery/README.md
+++ b/step_back_and_max_steer_recovery/README.md
@@ -6,6 +6,10 @@
 - 移動量、回転量で制御．制御量はパラメータで設定可能．
 - 移動中リアルタイムにcostmapを参照し，衝突前に停止する．許容距離はパラメータで設定可能．
 - 「後退→旋回→直進→反対旋回」or「後退→旋回」をパラメータで選択可能.
+- 行動前に障害物をチェック．障害物が存在したら下記に従って目標移動距離を修正．
+  - 修正前: hogehoge_length (パラメータ)
+  - 修正後: 障害物までの距離 - obstacle_patience (パラメータ)
+- 各動作毎にタイムアウトを設定可能．
 
 ## 挙動
 - 動画サンプル→https://www.youtube.com/watch?v=j6GID9XuiiU
@@ -23,7 +27,7 @@ recovery_behaviors:
   - {name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery}
   - {name: step_back_and_max_steer_recovery, type: step_back_and_max_steer_recovery/StepBackAndMaxSteerRecovery}
   - {name: aggressive_reset, type: clear_costmap_recovery/ClearCostmapRecovery}
-  
+
 step_back_and_max_steer_recovery:
     # 最初の一回だけ旋回したい場合にtrue
     only_single_steering: true
@@ -34,31 +38,42 @@ step_back_and_max_steer_recovery:
     obstacle_patience   : 0.3
     #-- 移動中に，障害物を確認する頻度[回/sec]
     obstacle_check_frequency: 5.0
-    # back(初回後退時の速度[m/s]と移動距離[m])
+    # 障害物探索時の角度の分解能[rad] costmapアクセス数を低減したいときに調整する．
+    sim_angle_resolution: 0.1
+    # back(初回後退時の速度[m/s], 移動距離[m], タイムアウト[sec])
     linear_vel_back     : -0.3
     step_back_length    : 1.0
-    # steer(旋回時の直進速度[m/s]，回転速さ(環境に寄って±が変わる)[rad/s]と目標回転角度[rad])
+    step_back_timeout   : 15.0
+    # steer(旋回時の速度[rad/s]と目標回転角度[rad], タイムアウト[sec])
     linear_vel_steer    : 0.3
     angular_speed_steer : 0.5
     turn_angle          : 1.5
-    # forward(旋回→直進→旋回の直進時の速度[m/s]と目標移動距離[m])
+    steering_timeout    : 15.0
+    # forward(旋回→直進→旋回の直進時の速度[m/s]と目標移動距離[m], タイムアウト[sec])
     linear_vel_forward  : 0.3
     step_forward_length : 1.0
+    step_forward_timeout: 15.0
+
 ```
 
 ### 使用時挙動
+
 - `move_base`立ち上げ時に以下のメッセージが出ていれば初期化成功
+
 ```bash
-[ INFO] [1476868343.792576518, 2448.560000000]: Initialized with only_single_steering = false
-[ INFO] [1476868343.792646641, 2448.560000000]: Initialized with recovery_trial_times = 3
-[ INFO] [1476868343.792669900, 2448.560000000]: Initialized with obstacle_patience = 0.50
-[ INFO] [1476868343.792698568, 2448.560000000]: Initialized with obstacle_check_frequency = 6.00
-[ INFO] [1476868343.792745858, 2448.560000000]: Initialized with linear_vel_back = -0.30, step_back_length = 8.00
-[ INFO] [1476868343.792777209, 2448.560000000]: Initialized with linear_vel_steer = 0.90, angular_speed_steer = 0.50, turn_angle = 1.00
-[ INFO] [1476868343.792811151, 2448.560000000]: Initialized with linear_vel_forward = 0.30, step_forward_length = 1.00
+[ INFO] [1476905975.890241798, 6973.810000000]: Initialized with only_single_steering = false
+[ INFO] [1476905975.890302193, 6973.810000000]: Initialized with recovery_trial_times = 3
+[ INFO] [1476905975.890322274, 6973.810000000]: Initialized with obstacle_patience = 0.50
+[ INFO] [1476905975.890340282, 6973.810000000]: Initialized with obstacle_check_frequency = 6.00
+[ INFO] [1476905975.890357877, 6973.810000000]: Initialized with sim_angle_resolution = 0.15
+[ INFO] [1476905975.890378780, 6973.810000000]: Initialized with linear_vel_back = -0.30, step_back_length = 8.00, step_back_steering = 3.00
+[ INFO] [1476905975.890576838, 6973.810000000]: Initialized with linear_vel_steer = 0.50, angular_speed_steer = 0.50, turn_angle = 2.00, steering_timeout = 3.10
+[ INFO] [1476905975.890605697, 6973.810000000]: Initialized with linear_vel_forward = 0.30, step_forward_length = 8.00, step_forward_timeout = 3.20
+
 ```
 
 - パラメータサーバに次のように登録されていればOK
+
 ```bash
 rosparam list | grep step_back_and_max_steer_recovery
 /move_base/step_back_and_max_steer_recovery/angular_speed_steer
@@ -68,16 +83,20 @@ rosparam list | grep step_back_and_max_steer_recovery
 /move_base/step_back_and_max_steer_recovery/obstacle_check_frequency
 /move_base/step_back_and_max_steer_recovery/obstacle_patience
 /move_base/step_back_and_max_steer_recovery/only_single_steering
+/move_base/step_back_and_max_steer_recovery/sim_angle_resolution
+/move_base/step_back_and_max_steer_recovery/steering_timeout
 /move_base/step_back_and_max_steer_recovery/step_back_length
+/move_base/step_back_and_max_steer_recovery/step_back_timeout
 /move_base/step_back_and_max_steer_recovery/step_forward_length
+/move_base/step_back_and_max_steer_recovery/step_forward_timeout
 /move_base/step_back_and_max_steer_recovery/trial_times
 /move_base/step_back_and_max_steer_recovery/turn_angle
-
 ```
 
 - リカバリ行動に入ったら以下のようなメッセージが出る．
   - 1秒に1回，移動横行と障害物までの最短距離を出力する．
   - 障害物発見時はWARNINGで表示．
+  
 ```bash
 [ INFO] [1476868375.829523527, 2480.590000000]: *****************************************************
 [ INFO] [1476868375.829690887, 2480.590000000]: **********Start StepBackAndSteerRecovery!!!**********
@@ -104,5 +123,25 @@ rosparam list | grep step_back_and_max_steer_recovery
 [ INFO] [1476868392.993863847, 2497.740000000]: *****************************************************
 [ INFO] [1476868392.993893442, 2497.740000000]: **********Finish StepBackAndSteerRecovery!!**********
 [ INFO] [1476868392.993917387, 2497.740000000]: *****************************************************
+```
 
+### WARNINGの種類
+
+- 移動前に障害物検知
+```bash
+ [ WARN] [1476906022.832819115, 7020.720000000]: obstacle detected before moving FORWARD
+ [ WARN] [1476906022.832909665, 7020.720000000]: min dist to obstacle = 2.97 [m] in FORWARD
+ [ WARN] [1476906022.832949896, 7020.720000000]: moving length is switched from 8.00 [m] to 1.97 in FORWARD
+```
+
+- 移動中に障害物検知
+```bash
+[ WARN] [1476868386.036249305, 2490.790000000]: obstacle detected at BACKWARD
+[ WARN] [1476868386.036298028, 2490.790000000]: min dist to obstacle = 0.48 [m] in BACKWARD
+```
+
+- タイムアウト
+```bash
+[ WARN] [1476906019.469352572, 7017.360000000]: time out at BACKWARD
+[ WARN] [1476906019.469436583, 7017.360000000]: 3.00 [sec] elapsed.
 ```

--- a/step_back_and_max_steer_recovery/README.md
+++ b/step_back_and_max_steer_recovery/README.md
@@ -40,6 +40,8 @@ step_back_and_max_steer_recovery:
     obstacle_check_frequency: 5.0
     # 障害物探索時の角度の分解能[rad] costmapアクセス数を低減したいときに調整する．
     sim_angle_resolution: 0.1
+    # 障害物探索時のsim更新周期[回/sec] costmapアクセス回数を低減したいときに調整する．
+    simulation_frequency    : 5
     # back(初回後退時の速度[m/s], 移動距離[m], タイムアウト[sec])
     linear_vel_back     : -0.3
     step_back_length    : 1.0
@@ -65,6 +67,7 @@ step_back_and_max_steer_recovery:
 [ INFO] [1476905975.890302193, 6973.810000000]: Initialized with recovery_trial_times = 3
 [ INFO] [1476905975.890322274, 6973.810000000]: Initialized with obstacle_patience = 0.50
 [ INFO] [1476905975.890340282, 6973.810000000]: Initialized with obstacle_check_frequency = 6.00
+[ INFO] [1476905975.890340282, 6973.810000000]: Initialized with simulation_frequency = 5.10
 [ INFO] [1476905975.890357877, 6973.810000000]: Initialized with sim_angle_resolution = 0.15
 [ INFO] [1476905975.890378780, 6973.810000000]: Initialized with linear_vel_back = -0.30, step_back_length = 8.00, step_back_steering = 3.00
 [ INFO] [1476905975.890576838, 6973.810000000]: Initialized with linear_vel_steer = 0.50, angular_speed_steer = 0.50, turn_angle = 2.00, steering_timeout = 3.10
@@ -84,6 +87,7 @@ rosparam list | grep step_back_and_max_steer_recovery
 /move_base/step_back_and_max_steer_recovery/obstacle_patience
 /move_base/step_back_and_max_steer_recovery/only_single_steering
 /move_base/step_back_and_max_steer_recovery/sim_angle_resolution
+/move_base/step_back_and_max_steer_recovery/simulation_frequency
 /move_base/step_back_and_max_steer_recovery/steering_timeout
 /move_base/step_back_and_max_steer_recovery/step_back_length
 /move_base/step_back_and_max_steer_recovery/step_back_timeout

--- a/step_back_and_max_steer_recovery/config/planner_sample.yaml
+++ b/step_back_and_max_steer_recovery/config/planner_sample.yaml
@@ -15,13 +15,18 @@ step_back_and_max_steer_recovery:
     obstacle_patience   : 0.3
     #-- 移動中に，障害物を確認する頻度[回/sec]
     obstacle_check_frequency: 5.0
-    # back(初回後退時の速度[m/s]と移動距離[m])
+    # 障害物探索時の角度の分解能[rad] costmapアクセス数を低減したいときに調整する．
+    sim_angle_resolution: 0.1
+    # back(初回後退時の速度[m/s], 移動距離[m], タイムアウト[sec])
     linear_vel_back     : -0.3
     step_back_length    : 1.0
-    # steer(旋回時の速度[rad/s]と目標回転角度[rad])
+    step_back_timeout   : 15.0
+    # steer(旋回時の速度[rad/s]と目標回転角度[rad], タイムアウト[sec])
     linear_vel_steer    : 0.3
     angular_speed_steer : 0.5
     turn_angle          : 1.5
-    # forward(旋回→直進→旋回の直進時の速度[m/s]と目標移動距離[m])
+    steering_timeout    : 15.0
+    # forward(旋回→直進→旋回の直進時の速度[m/s]と目標移動距離[m], タイムアウト[sec])
     linear_vel_forward  : 0.3
     step_forward_length : 1.0
+    step_forward_timeout: 15.0

--- a/step_back_and_max_steer_recovery/config/planner_sample.yaml
+++ b/step_back_and_max_steer_recovery/config/planner_sample.yaml
@@ -15,18 +15,20 @@ step_back_and_max_steer_recovery:
     obstacle_patience   : 0.3
     #-- 移動中に，障害物を確認する頻度[回/sec]
     obstacle_check_frequency: 5.0
-    # 障害物探索時の角度の分解能[rad] costmapアクセス数を低減したいときに調整する．
+    # 障害物探索時の角度の分解能[rad] costmapアクセス回数を低減したいときに調整する．
     sim_angle_resolution: 0.1
+    # 障害物探索時のsim更新周期 [回/sec] costmapアクセス回数を低減したいときに調整する．
+    simulation_frequency    : 5
     # back(初回後退時の速度[m/s], 移動距離[m], タイムアウト[sec])
     linear_vel_back     : -0.3
     step_back_length    : 1.0
     step_back_timeout   : 15.0
-    # steer(旋回時の速度[rad/s]と目標回転角度[rad], タイムアウト[sec])
+    # steer(旋回時の速度[rad/s], 目標回転角度[rad], タイムアウト[sec])
     linear_vel_steer    : 0.3
     angular_speed_steer : 0.5
     turn_angle          : 1.5
     steering_timeout    : 15.0
-    # forward(旋回→直進→旋回の直進時の速度[m/s]と目標移動距離[m], タイムアウト[sec])
+    # forward(旋回→直進→旋回の直進時の速度[m/s], 目標移動距離[m], タイムアウト[sec])
     linear_vel_forward  : 0.3
     step_forward_length : 1.0
     step_forward_timeout: 15.0

--- a/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
+++ b/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
@@ -132,13 +132,16 @@ private:
   //-- back
   double linear_vel_back_;
   double step_back_length_;
+  double step_back_timeout_;
   //-- steer
   double linear_vel_steer_;
   double angular_speed_steer_;
   double turn_angle_;
+  double steering_timeout_;
   //-- forward
   double linear_vel_forward_;
   double step_forward_length_;
+  double step_forward_timeout_;
 
 };
 

--- a/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
+++ b/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
@@ -100,6 +100,7 @@ private:
   double getCurrentDistDiff(const gm::Pose2D initialPose, const double distination, COSTMAP_SEARCH_MODE mode = FORWARD);
   double getMinimalDistanceToObstacle(const COSTMAP_SEARCH_MODE mode);
   int determineTurnDirection();
+  double getDistBetweenTwoPoints(const gm::Pose2D pose1, const gm::Pose2D pose2);
 
 
   ros::NodeHandle nh_;

--- a/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
+++ b/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
@@ -130,6 +130,7 @@ private:
   double linear_acceleration_limit_;
   double angular_acceleration_limit_;
   double controller_frequency_;
+  double simulation_frequency_;
   double simulation_inc_;
 
   bool only_single_steering_;

--- a/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
+++ b/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
@@ -94,13 +94,12 @@ private:
   gm::Pose2D getPoseToObstacle (const gm::Pose2D& current, const gm::Twist& twist) const;
   double normalizedPoseCost (const gm::Pose2D& pose) const;
   gm::Twist transformTwist (const gm::Pose2D& pose) const;
-  void moveSpacifiedLength (const gm::Twist twist, const double duaration) const;
-  void moveSpacifiedLength (const gm::Twist twist, double length, COSTMAP_SEARCH_MODE mode = FORWARD);
-  double getCurrentDiff(const gm::Pose2D initialPose, COSTMAP_SEARCH_MODE mode = FORWARD);
-  double getCurrentDistDiff(const gm::Pose2D initialPose, const double distination, COSTMAP_SEARCH_MODE mode = FORWARD);
-  double getMinimalDistanceToObstacle(const COSTMAP_SEARCH_MODE mode);
+  void moveSpacifiedLength (const gm::Twist twist, const double length, const COSTMAP_SEARCH_MODE mode = FORWARD) const;
+  double getCurrentDiff(const gm::Pose2D initialPose, const COSTMAP_SEARCH_MODE mode = FORWARD) const;
+  double getCurrentDistDiff(const gm::Pose2D initialPose, const double distination, const COSTMAP_SEARCH_MODE mode = FORWARD) const;
+  double getMinimalDistanceToObstacle(const COSTMAP_SEARCH_MODE mode) const;
   int determineTurnDirection();
-  double getDistBetweenTwoPoints(const gm::Pose2D pose1, const gm::Pose2D pose2);
+  double getDistBetweenTwoPoints(const gm::Pose2D pose1, const gm::Pose2D pose2) const;
 
 
   ros::NodeHandle nh_;

--- a/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
+++ b/step_back_and_max_steer_recovery/include/step_back_and_max_steer_recovery/step_back_and_max_steer_recovery.h
@@ -87,6 +87,13 @@ private:
     RIGHT,
   };
 
+  enum TURN_NO
+  {
+    FIRST_TURN = 0,
+    SECOND_TURN = 1,
+  };
+  static const int CNT_TURN = 2;
+
   gm::Twist TWIST_STOP;
 
   gm::Pose2D getCurrentLocalPose () const;
@@ -129,6 +136,7 @@ private:
   int trial_times_;
   double obstacle_patience_;
   double obstacle_check_frequency_;
+  double sim_angle_resolution_;
   //-- back
   double linear_vel_back_;
   double step_back_length_;

--- a/step_back_and_max_steer_recovery/src/step_back_and_max_steer_recovery.cpp
+++ b/step_back_and_max_steer_recovery/src/step_back_and_max_steer_recovery.cpp
@@ -104,7 +104,7 @@ void StepBackAndMaxSteerRecovery::initialize (std::string name, tf::TransformLis
   private_nh.param("trial_times", trial_times_, 5);
   private_nh.param("obstacle_patience", obstacle_patience_, 0.5);
   private_nh.param("obstacle_check_frequency", obstacle_check_frequency_, 5.0);
-  private_nh.param("sim_angle_resolution_", sim_angle_resolution_, 0.1);
+  private_nh.param("sim_angle_resolution", sim_angle_resolution_, 0.1);
 
   // back
   private_nh.param("linear_vel_back", linear_vel_back_, -0.3);
@@ -129,6 +129,7 @@ void StepBackAndMaxSteerRecovery::initialize (std::string name, tf::TransformLis
   ROS_INFO_NAMED ("top", "Initialized with recovery_trial_times = %d", trial_times_);
   ROS_INFO_NAMED ("top", "Initialized with obstacle_patience = %.2f", obstacle_patience_);
   ROS_INFO_NAMED ("top", "Initialized with obstacle_check_frequency = %.2f", obstacle_check_frequency_);
+  ROS_INFO_NAMED ("top", "Initialized with sim_angle_resolution = %.2f", sim_angle_resolution_);
   ROS_INFO_NAMED ("top", "Initialized with linear_vel_back = %.2f, step_back_length = %.2f, step_back_steering = %.2f",
                   linear_vel_back_, step_back_length_, step_back_timeout_);
   ROS_INFO_NAMED ("top", "Initialized with linear_vel_steer = %.2f, angular_speed_steer = %.2f,"

--- a/step_back_and_max_steer_recovery/src/step_back_and_max_steer_recovery.cpp
+++ b/step_back_and_max_steer_recovery/src/step_back_and_max_steer_recovery.cpp
@@ -98,7 +98,8 @@ void StepBackAndMaxSteerRecovery::initialize (std::string name, tf::TransformLis
   private_nh.param("linear_acceleration_limit", linear_acceleration_limit_, 4.0);
   private_nh.param("angular_acceleration_limit", angular_acceleration_limit_, 3.2);
   private_nh.param("controller_frequency", controller_frequency_, 20.0);
-  private_nh.param("simulation_inc", simulation_inc_, 1/controller_frequency_);
+  private_nh.param("simulation_frequency", simulation_frequency_, 5.0);
+  private_nh.param("simulation_inc", simulation_inc_, 1/simulation_frequency_);
 
   private_nh.param("only_single_steering", only_single_steering_, true);
   private_nh.param("trial_times", trial_times_, 5);
@@ -129,6 +130,7 @@ void StepBackAndMaxSteerRecovery::initialize (std::string name, tf::TransformLis
   ROS_INFO_NAMED ("top", "Initialized with recovery_trial_times = %d", trial_times_);
   ROS_INFO_NAMED ("top", "Initialized with obstacle_patience = %.2f", obstacle_patience_);
   ROS_INFO_NAMED ("top", "Initialized with obstacle_check_frequency = %.2f", obstacle_check_frequency_);
+  ROS_INFO_NAMED ("top", "Initialized with simulation_frequency = %.2f", simulation_frequency_);
   ROS_INFO_NAMED ("top", "Initialized with sim_angle_resolution = %.2f", sim_angle_resolution_);
   ROS_INFO_NAMED ("top", "Initialized with linear_vel_back = %.2f, step_back_length = %.2f, step_back_steering = %.2f",
                   linear_vel_back_, step_back_length_, step_back_timeout_);
@@ -239,7 +241,7 @@ gm::Twist StepBackAndMaxSteerRecovery::scaleGivenAccelerationLimits (const gm::T
   return scaleTwist(twist, max(1.0, max(acc_scaling, vel_scaling)));
 }
 
-// Get pose in local costmap frame
+// Get pose in local costmap framoe
 gm::Pose2D StepBackAndMaxSteerRecovery::getCurrentLocalPose () const
 {
   tf::Stamped<tf::Pose> p;
@@ -370,9 +372,7 @@ double StepBackAndMaxSteerRecovery::getCurrentDiff(const gm::Pose2D initialPose,
     switch (mode) {
     case FORWARD:
     case BACKWARD:
-        current_diff = (currentPose.x - initialPose.x)*(currentPose.x - initialPose.x) +
-                (currentPose.y - initialPose.y)*(currentPose.y - initialPose.y);
-        current_diff = sqrt(current_diff);
+        current_diff = getDistBetweenTwoPoints(currentPose, initialPose);
         ROS_DEBUG_NAMED ("top", "current_diff in translation = %.2f", current_diff);
         break;
     case FORWARD_LEFT:

--- a/step_back_and_max_steer_recovery/src/step_back_and_max_steer_recovery.cpp
+++ b/step_back_and_max_steer_recovery/src/step_back_and_max_steer_recovery.cpp
@@ -265,7 +265,7 @@ void StepBackAndMaxSteerRecovery::moveSpacifiedLength (const gm::Twist twist, co
         time_out = step_forward_timeout_;
         if (min_dist_to_obstacle < distination)
         {
-          distination_cmd = min_dist_to_obstacle - 2 * obstacle_patience_;
+          distination_cmd = min_dist_to_obstacle - obstacle_patience_;
 
           ROS_WARN_NAMED ("top", "obstacle detected before moving %s", mode_name.c_str());
           ROS_WARN_NAMED ("top", "min dist to obstacle = %.2f [m] in %s", min_dist_to_obstacle, mode_name.c_str());

--- a/third_robot_2dnav/params/base_local_planner_params.yaml
+++ b/third_robot_2dnav/params/base_local_planner_params.yaml
@@ -40,16 +40,21 @@ step_back_and_max_steer_recovery:
     obstacle_patience   : 0.3
     #-- 移動中に，障害物を確認する頻度[回/sec]
     obstacle_check_frequency: 5.0
-    # back(初回後退時の速度[m/s]と移動距離[m])
+    # 障害物探索時の角度の分解能[rad] costmapアクセス数を低減したいときに調整する．
+    sim_angle_resolution: 0.1
+    # back(初回後退時の速度[m/s], 移動距離[m], タイムアウト[sec])
     linear_vel_back     : -1.5
     step_back_length    : 1.5
-    # steer(旋回時の直進速度[m/s]，回転速さ(環境に寄って±が変わる)[rad/s]と目標回転角度[rad])
+    step_back_timeout   : 15.0
+    # steer(旋回時の直進速度[m/s], 回転速さ(環境に寄って±が変わる)[rad/s], 目標回転角度[rad], タイムアウト[sec])
     linear_vel_steer    : 0.3
     angular_speed_steer : 1.0
     turn_angle          : 0.78
-    # forward(旋回→直進→旋回の直進時の速度[m/s]と目標移動距離[m])
+    steering_timeout    : 15.0
+        # forward(旋回→直進→旋回の直進時の速度[m/s], 目標移動距離[m])
     linear_vel_forward  : 0.3
     step_forward_length : 1.0
+    step_forward_timeout: 15.0
 
 TebLocalPlannerROS:
 


### PR DESCRIPTION
下記について改善しています．
- [x] 各移動動作にタイムアウトを設ける
  - タイムアウトはデフォルトでは15 [sec] としています．
- [x] 最短障害物検知時のコストマップへのアクセス頻度をもう少し改善する
  - もしリカバリ中にまた`Map なんちゃら`のワーニングが出たら，パラメータ`sim_angle_resolution`の値を大きくする(例えば0.2[rad]→約12[deg]ずつ探索)とするとcostmapへのアクセス頻度は低減します．
  - ただ，その隙間に障害物があると検知できなくなるので，あまり大きくするのも問題です．

適宜調整ください．
