### PR TITLE
Add teb planner

### DIFF
--- a/third_robot_2dnav_gazebo/config/autorun_gazebo.rviz
+++ b/third_robot_2dnav_gazebo/config/autorun_gazebo.rviz
@@ -444,7 +444,7 @@ Visualization Manager:
             X: 0
             Y: 0
             Z: 0
-          Topic: /move_base/TrajectoryPlannerROS/global_plan
+          Topic: /move_base/TebLocalPlannerROS/global_plan
           Unreliable: false
           Value: true
         - Alpha: 1
@@ -459,7 +459,7 @@ Visualization Manager:
             X: 0
             Y: 0
             Z: 0
-          Topic: /move_base/TrajectoryPlannerROS/local_plan
+          Topic: /move_base/TebLocalPlannerROS/local_plan
           Unreliable: false
           Value: true
         - Alpha: 1
@@ -567,5 +567,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1659
-  X: 86
-  Y: 144
+  X: 66
+  Y: 124

--- a/third_robot_2dnav_gazebo/launch/move_base.launch
+++ b/third_robot_2dnav_gazebo/launch/move_base.launch
@@ -9,6 +9,8 @@
   <node pkg="topic_tools" type="relay" name="relay_cmd_vel" args="/cmd_vel /steer_drive_controller/cmd_vel"/>
 
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
+    <param name="base_local_planner" value="teb_local_planner/TebLocalPlannerROS" />
+    <!-- <param name="base_local_planner" value="dwa_local_planner/DWAPlannerROS" /> -->
     <rosparam file="$(find third_robot_2dnav_gazebo)/params/costmap_common_params.yaml" command="load" ns="global_costmap" />
     <rosparam file="$(find third_robot_2dnav_gazebo)/params/costmap_common_params.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find third_robot_2dnav_gazebo)/params/local_costmap_params.yaml" command="load" />

--- a/third_robot_2dnav_gazebo/params/base_local_planner_params.yaml
+++ b/third_robot_2dnav_gazebo/params/base_local_planner_params.yaml
@@ -56,3 +56,132 @@ step_back_and_max_steer_recovery:
     step_forward_length : 1.0
     step_forward_timeout: 15.0
 
+DWAPlannerROS:
+  # Robot configuration parameters  
+  acc_lim_x: 2.5
+  acc_lim_y: 0
+  acc_lim_th: 3.2
+
+  max_vel_x: 3.0
+  min_vel_x: -0.5
+  max_vel_y: 0
+  min_vel_y: 0
+
+  max_trans_vel: 3.0
+  min_trans_vel: 0.1
+  max_rot_vel: 1.5
+  min_rot_vel: 0.2
+
+  # Goal Tolerance Parameters
+  yaw_goal_tolerance: 0.1
+  xy_goal_tolerance: 0.2
+  latch_xy_goal_tolerance: false
+
+  # # Forward Simulation Parameters
+  # sim_time: 2.0
+  # sim_granularity: 0.02
+  # vx_samples: 6
+  # vy_samples: 0
+  # vtheta_samples: 20
+  # penalize_negative_x: true
+
+  # # Trajectory scoring parameters
+  # path_distance_bias: 32.0 # The weighting for how much the controller should stay close to the path it was given
+  # goal_distance_bias: 24.0 # The weighting for how much the controller should attempt to reach its local goal, also controls speed
+  #occdist_scale: 0.2 # The weighting for how much the controller should attempt to avoid obstacles
+  # forward_point_distance: 0.325 # The distance from the center point of the robot to place an additional scoring point, in meters
+  # stop_time_buffer: 0.2  # The amount of time that the robot must stThe absolute value of the veolicty at which to start scaling the robot's footprint, in m/sop before a collision in order for a trajectory to be considered valid in seconds
+  # scaling_speed: 0.25 # The absolute value of the veolicty at which to start scaling the robot's footprint, in m/s
+  # max_scaling_factor: 0.2 # The maximum factor to scale the robot's footprint by
+  #
+ 
+TebLocalPlannerROS:
+
+    # odom_topic: odom
+    # map_frame: /map
+    # Trajectory
+    #  
+    #teb_autosize: True
+    dt_ref: 0.6
+    #dt_hysteresis: 0.1
+    # global_plan_overwrite_orientation: True
+    max_global_plan_lookahead_dist: 2.0
+    # feasibility_check_no_poses: 2
+    #    
+    # Robot
+            
+    max_vel_x: 3.0
+    max_vel_x_backwards: 5.0
+    max_vel_y: 0.0
+    max_vel_theta: 1.1 # the angular velocity is also bounded by min_turning_radius in case of a carlike robot (r = v / omega)
+    acc_lim_x: 5.0
+    acc_lim_theta: 1.1
+    #
+    # # ********************** Carlike robot parameters ********************
+    min_turning_radius: 1.95        # Min turning radius of the carlike robot (compute value using a model or adjust with rqt_reconfigure manually)
+    wheelbase: 2.0                 # Wheelbase of our robot
+    cmd_angle_instead_rotvel: True # stage simulator takes the angle instead of the rotvel as input (twist message)
+    # # ********************************************************************
+    #
+    footprint_model: # types: "point", "circular", "two_circles", "line", "polygon"
+       type: "point"
+    #   radius: 0.2 # for type "circular"
+    #    #line_start: [-1.0, 0.0] # for type "line"
+    #    #line_end: [1.0, 0.0] # for type "line"
+    #   front_offset: 0.2 # for type "two_circles"
+    #   front_radius: 0.2 # for type "two_circles"
+    #   rear_offset: 0.2 # for type "two_circles"
+    #   rear_radius: 0.2 # for type "two_circles"
+    #   vertices: [[1.00, 0.45], [1.00, -0.45], [-0.15, -0.45], [-0.15, 0.45]] # for type "polygon"
+    #   footprint: [[0.55, 0.35], [0.55, -0.35], [-0.55, -0.35], [-0.55, 0.35]] #third
+    #
+    # # GoalTolerance
+    #    
+    # xy_goal_tolerance: 1.0
+    # yaw_goal_tolerance: 0.5
+    # free_goal_vel: False
+    #    
+    # Obstacles
+    #    
+    # min_obstacle_dist: 0.25 # This value must also include our robot's expansion, since footprint_model is set to "line".
+    # include_costmap_obstacles: True
+    # costmap_obstacles_behind_robot_dist: 1.0
+    obstacle_poses_affected: 20
+    # costmap_converter_plugin: ""
+    # costmap_converter_spin_thread: True
+    # costmap_converter_rate: 5
+    
+    # Optimization
+        
+    no_inner_iterations: 4
+    no_outer_iterations: 3
+    # optimization_activate: True
+    # optimization_verbose: False
+    # penalty_epsilon: 0.1
+    # weight_max_vel_x: 2
+    # weight_max_vel_theta: 1
+    # weight_acc_lim_x: 1
+    # weight_acc_lim_theta: 1
+    # weight_kinematics_nh: 1000
+    # weight_kinematics_forward_drive: 1
+    # weight_kinematics_turning_radius: 1
+    # weight_optimaltime: 1
+    # weight_obstacle: 50
+    # weight_dynamic_obstacle: 10 # not in use yet
+    #
+    # Homotopy Class Planner
+    #
+    # enable_homotopy_class_planning: True
+    # enable_multithreading: True
+    # simple_exploration: False
+    # max_number_classes: 4
+    # selection_cost_hysteresis: 1.0
+    # selection_obst_cost_scale: 1.0
+    # selection_alternative_time_cost: False
+    # roadmap_graph_no_samples: 15
+    # roadmap_graph_area_width: 5
+    # h_signature_prescaler: 0.5
+    # h_signature_threshold: 0.1
+    # obstacle_keypoint_offset: 0.1
+    # obstacle_heading_threshold: 0.45
+    # visualize_hc_graph: False#

--- a/third_robot_2dnav_gazebo/params/base_local_planner_params.yaml
+++ b/third_robot_2dnav_gazebo/params/base_local_planner_params.yaml
@@ -37,7 +37,7 @@ step_back_and_max_steer_recovery:
     trial_times         : 3
     # 障害物までの許容距離[m]．
     #-- 移動中に，移動方向に対して最も近い障害物がこの距離以内に出現したら停止する．
-    obstacle_patience   : 0.3
+    obstacle_patience   : 0.4
     #-- 移動中に，障害物を確認する頻度[回/sec]
     obstacle_check_frequency: 5.0
     # 障害物探索時の角度の分解能[rad] costmapアクセス数を低減したいときに調整する．

--- a/third_robot_2dnav_gazebo/params/costmap_common_params.yaml
+++ b/third_robot_2dnav_gazebo/params/costmap_common_params.yaml
@@ -1,6 +1,6 @@
 obstacle_range: 9.5 #2.5
 raytrace_range: 10.0
-footprint: [[0.55, 0.35], [0.55, -0.35], [-0.55, -0.35], [-0.55, 0.35]] #third
+footprint: [[0.65, 0.35], [0.65, -0.35], [-0.65, -0.35], [-0.65, 0.35]] #third
 #footprint: [[0.3, 0.25], [0.3, -0.25], [-0.47, -0.25], [-0.47, 0.25]] #fourth
 #robot_radius: ir_of_robot
 inflation_radius: 0.5 #1.0

--- a/third_robot_2dnav_gazebo/params/local_costmap_params.yaml
+++ b/third_robot_2dnav_gazebo/params/local_costmap_params.yaml
@@ -7,5 +7,5 @@ local_costmap:
   rolling_window: true
   width: 10.0
   height: 10.0
-  resolution: 0.10
+  resolution: 0.20
   transform_tolerance: 1.5

--- a/third_robot_gazebo/config/third_robot_steer_drive_controller.yaml
+++ b/third_robot_gazebo/config/third_robot_steer_drive_controller.yaml
@@ -17,7 +17,7 @@ steer_drive_controller:
 
     pose_covariance_diagonal : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
     twist_covariance_diagonal: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    wheel_separation_multiplier: 1.2
+    wheel_separation_multiplier: 1.35
     wheel_radius_multiplier    : 0.5
     cmd_vel_timeout: 20
     base_frame_id: base_link


### PR DESCRIPTION
Gazebo において，teb_plannerで計算時間の警告が出なくなる程度にパラメータを調整しました．
- コントローラが20Hzで回っているので，少なくともそれよりは速く動いているはずです．
- `third_robot_2dnav_gazebo` で動かす限りは，さくさくで経路もいい感じに求めてくれています．
- ただ，`local_costmap`のresolutionを0.2にすることが一番効いたようなので，tebのチューニングが出来たのかと言われると少し怪しいです．
- 旋回して前後に移動頻度が格段に上がるので，回転方向のオドメトリのキャリブレーションはしっかりやらないと自己位置推定がずれます．注意です．
- 以下のコマンドで遊べます．

```
roslaunch third_robot_2dnav_gazebo autorun.launch
```
